### PR TITLE
Revert "fix skip letter typo `resoled` at line 387 to `resolved`"

### DIFF
--- a/Assignments/Assignment-typo.md
+++ b/Assignments/Assignment-typo.md
@@ -384,7 +384,7 @@ For problems with some depth, it is appropriate to post a summary of the trouble
 
 Besides being courteous and informative, this sort of followup will help others searching the archive of the mailing-list/newsgroup/forum to know exactly which solution helped you and thus may also help them.
 
-Last, and not least, this sort of followup helps everybody who assisted feel a satisfying sense of closure about the problem. If you are not a techie or hacker yourself, trust us that this feeling is very important to the gurus and experts you tapped for help. Problem narratives that trail off into unresolved nothingness are frustrating things; hackers itch to see them resolved. The goodwill that scratching that itch earns you will bevery, very helpful to you next time you need to pose a question.
+Last, and not least, this sort of followup helps everybody who assisted feel a satisfying sense of closure about the problem. If you are not a techie or hacker yourself, trust us that this feeling is very important to the gurus and experts you tapped for help. Problem narratives that trail off into unresolved nothingness are frustrating things; hackers itch to see them resoled. The goodwill that scratching that itch earns you will bevery, very helpful to you next time you need to pose a question.
 
 Consider how you might be able to prevent others from having the same problem in the future. Ask yourself if a documentation or FAQ patch would help, and if the answer is yes send that patch to the maintainer.
 


### PR DESCRIPTION
Reverts HaoyangShi/oss101#2
merge into main wrongly